### PR TITLE
Setting flag for unbuffered stdout and stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN apt update && apt install -y python3 python3-pip curl
 COPY ./mms_helper.py /
 WORKDIR /
 
-CMD python3 mms_helper.py
+CMD ["python3", "-u", "mms_helper.py"]
 


### PR DESCRIPTION
According `python --help`:

```
-u     : unbuffered binary stdout and stderr; also PYTHONUNBUFFERED=x
         see man page for details on internal buffering relating to '-u'
```

If not set at least on Mac `docker logs` doesn't show logs in real time, hard to follow the flow of app.